### PR TITLE
Refactor tests with rstest fixing a number of bugs along the way

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
+          cargo +nightly tarpaulin --verbose --workspace --timeout 120 --out xml
 
       - name: Code coverage summary
         uses: irongut/CodeCoverageSummary@v1.3.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  pull-requests: write
+
 jobs:
   collect:
     name: Collect
@@ -31,6 +34,7 @@ jobs:
           thresholds: "50 75"
           fail_below_min: true
           format: markdown
+          hide_complexity: true
           output: both
           badge: true
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,14 @@ jobs:
 
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --verbose --workspace --timeout 120 --out xml
+          cargo +nightly tarpaulin \
+            --verbose \
+            --all-features \
+            --workspace \
+            --timeout 120 \
+            --out xml \
+            --exclude-files tests/* \
+            --exclude-files examples/*
 
       - name: Code coverage summary
         uses: irongut/CodeCoverageSummary@v1.3.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Use Rust cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Generate code coverage
         run: |
           cargo +nightly tarpaulin \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,42 @@
+name: Test coverage
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  collect:
+    name: Collect
+    runs-on: ubuntu-latest
+    container:
+      image: xd009642/tarpaulin:develop-nightly
+      options: --security-opt seccomp=unconfined
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate code coverage
+        run: |
+          cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
+
+      - name: Code coverage summary
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: cobertura.xml
+          thresholds: "50 75"
+          fail_below_min: true
+          format: markdown
+          output: both
+          badge: true
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: code-coverage-results.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,13 +215,15 @@ dependencies = [
  "diesel-async",
  "diesel_migrations",
  "directories",
+ "eyre",
  "futures-util",
  "http-test-server",
  "rand 0.9.0",
  "reqwest",
+ "rstest",
  "serde",
  "sha256",
- "tempdir",
+ "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tokio-cron-scheduler",
@@ -604,6 +606,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,12 +650,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures-channel"
@@ -689,6 +695,12 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -749,6 +761,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
@@ -1180,6 +1198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1575,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,19 +1663,6 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -1685,21 +1705,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -1714,15 +1719,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1781,13 +1777,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
+name = "relative-path"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
@@ -1855,6 +1848,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,6 +1888,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1980,6 +2012,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -2192,16 +2230,6 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ diesel-async = { version = "0.5", features = [
     "deadpool",
 ] }
 diesel_migrations = "2"
+eyre = "0.6"
 futures-util = "0.3"
 reqwest = { version = "0.12", features = ["rustls-tls", "stream"] }
 thiserror = "2"
@@ -45,8 +46,9 @@ sha256 = "1.5"
 [dev-dependencies]
 http-test-server = "2"
 rand = "0.9"
+rstest = "0.25"
 serde = { version = "1", features = ["derive"] }
-tempdir = "0.3"
+tempfile = "3"
 tokio-cron-scheduler = { version = "0.13", features = ["signal"] }
 tokio-test = "0.4"
 tracing-test = "0.2"

--- a/examples/web_api.rs
+++ b/examples/web_api.rs
@@ -50,7 +50,8 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     // This client builder will be used in our clients pool
-    let client_builder = Client::builder(DATABASE_URL, CACHE_DIR)
+    let mut client_builder = Client::builder(DATABASE_URL, CACHE_DIR);
+    client_builder
         .default_file_duration(Duration::from_secs(30))
         .download_retry_policy(RetryPolicy::Fixed {
             number: 3,

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,14 +4,14 @@ use std::time::Duration;
 
 use reqwest::Client as ReqwestClient;
 use tokio::fs;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncWriteExt, Error as IoError};
 use tokio::time;
 use tokio_stream::StreamExt;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, trace};
 
 use crate::database::models::CacheEntry;
 use crate::database::{self, api, Connection};
-use crate::errors::{Error, NonUtf8PathError};
+use crate::errors::{CleanUpError, DatabaseError, Error, NonUtf8PathError};
 use crate::{DateTime, File, FileStatus, RetryPolicy, Utc};
 
 type StdResult<T, E> = std::result::Result<T, E>;
@@ -44,7 +44,7 @@ impl ClientBuilder {
     /// Set [`reqwest::Client`] to use for downloading.
     ///
     /// If not set, [`Client`] will build default [`reqwest::Client`] on initialization.
-    pub fn reqwest_client(mut self, reqwest_client: ReqwestClient) -> Self {
+    pub fn reqwest_client(&mut self, reqwest_client: ReqwestClient) -> &mut Self {
         self.reqwest_client = Some(reqwest_client);
         self
     }
@@ -54,7 +54,7 @@ impl ClientBuilder {
     /// `duration` will be added to [`Utc::now()`] and set as an expiration timestamp when
     /// downloading a file. If not set, new files won't have any expiration timestamp and
     /// will never expire.
-    pub fn default_file_duration(mut self, duration: Duration) -> Self {
+    pub fn default_file_duration(&mut self, duration: Duration) -> &mut Self {
         self.default_file_duration = Some(duration);
         self
     }
@@ -63,7 +63,7 @@ impl ClientBuilder {
     /// Applies only to downloading process during [`Client::get`].
     ///
     /// If not set, [`RetryPolicy::None`] will be used.
-    pub fn download_retry_policy(mut self, policy: RetryPolicy) -> Self {
+    pub fn download_retry_policy(&mut self, policy: RetryPolicy) -> &mut Self {
         self.download_retry_policy = policy;
         self
     }
@@ -172,33 +172,26 @@ impl Client {
         )
         .await;
 
-        let entry = match result {
+        match result {
             Ok(entry) => {
                 // File was not in cache, so let's download it
                 debug!("cache miss: {:?}", entry);
-                let result = self.fetch_entry(&entry).await;
-                match result {
-                    Ok(entry) => entry,
-                    Err(err) => match self.download_retry_policy {
-                        RetryPolicy::None => return Err(err),
-                        RetryPolicy::Fixed { number, period } => {
-                            let mut result = Err(err);
-
-                            // retry cycle
-                            for i in 0..number {
-                                time::sleep(period).await;
-                                debug!("retrying fetch URL '{}', attempt #{}", entry.url, i + 1);
-                                match self.fetch_entry(&entry).await {
-                                    Ok(entry) => {
-                                        result = Ok(entry);
-                                        break;
-                                    }
-                                    Err(err) => result = Err(err),
-                                }
-                            }
-
-                            // latest occured error will be thrown
-                            result?
+                match self.fetch_entry_with_retry(&entry).await {
+                    Ok(entry) => {
+                        // At this point file was downloaded and stored in cache
+                        // If this function fails, it means that we only failed
+                        // to increment the reference counter. So it is safe
+                        // to just return an error here and let user call `get()` again.
+                        self.create_locked_file(entry).await
+                    }
+                    Err(download_error) => match self.cleanup_entry(&entry).await {
+                        Ok(_) => Err(download_error),
+                        Err((remove_file_error, database_error)) => {
+                            Err(Error::CleanUpError(Box::new(CleanUpError {
+                                remove_file_error,
+                                database_error,
+                                download_error,
+                            })))
                         }
                     },
                 }
@@ -206,16 +199,16 @@ impl Client {
             Err(err) if err.is_unique_violation() => {
                 // File is already in cache
                 debug!("cache hit: {}", url);
-                self.wait_entry(url).await?
-            }
-            Err(err) => return Err(err.into()),
-        };
+                let entry = self.wait_entry(url).await?;
 
-        // At this point file was downloaded and stored in cache
-        // If this function fails, it means that we only failed
-        // to increment the reference counter. So it is safe
-        // to just return an error here and let user call `get()` again.
-        self.create_locked_file(entry).await
+                // At this point file was downloaded and stored in cache
+                // If this function fails, it means that we only failed
+                // to increment the reference counter. So it is safe
+                // to just return an error here and let user call `get()` again.
+                self.create_locked_file(entry).await
+            }
+            Err(err) => Err(err.into()),
+        }
     }
 
     /// Find file by URL in cache. Returns `None` is URL is not cached.
@@ -390,84 +383,81 @@ impl Client {
         }
     }
 
-    /// Query entry URL and store response body in target file. Then update entry status.
-    /// If anything fails during this process, clean-up trimmed file and cache entry.
-    async fn fetch_entry(&mut self, entry: &CacheEntry) -> Result<CacheEntry> {
-        let mut file = fs::File::create_new(&entry.cache_path).await?;
+    /// Fetch entry with respect to donwloading retry policy.
+    async fn fetch_entry_with_retry(&mut self, entry: &CacheEntry) -> Result<CacheEntry> {
+        match self.fetch_entry(entry).await {
+            Ok(entry) => Ok(entry),
+            Err(err) => match self.download_retry_policy {
+                RetryPolicy::None => Err(err),
+                RetryPolicy::Fixed { number, period } => {
+                    let mut result = Err(err);
 
-        let mut fetch = async || -> Result<CacheEntry> {
-            trace!("fetching {}", &entry.url);
-            let response = self
-                .reqwest_client
-                .get(&entry.url)
-                .send()
-                .await?
-                .error_for_status()?;
-            let code = response.status().as_u16();
-            if code != 200 {
-                // For responses with 2XX codes we probably only interested in 200.
-                return Err(Error::CustomError(format!(
-                    "HTTP response status code {}",
-                    code
-                )));
-            }
-            let mut stream = response.bytes_stream();
-            while let Some(chunk_result) = stream.next().await {
-                let chunk = chunk_result?;
-                file.write_all(&chunk).await?;
-            }
-            let updated_entry =
-                api::update_status(&mut self.db, entry.id, FileStatus::Ready).await?;
-            Ok(updated_entry)
-        };
+                    // retry cycle
+                    for i in 0..number {
+                        time::sleep(period).await;
+                        debug!("retrying fetch URL '{}', attempt #{}", entry.url, i + 1);
+                        match self.fetch_entry(entry).await {
+                            Ok(entry) => {
+                                result = Ok(entry);
+                                break;
+                            }
+                            Err(err) => result = Err(err),
+                        }
+                    }
 
-        match fetch().await {
-            Ok(updated_entry) => Ok(updated_entry),
-            Err(err) => {
-                // cleanup before returning
-                // just log error because we already have main error to return
-                let failed_to_update = api::update_status(&mut self.db, entry.id, FileStatus::Corrupted)
-                    .await
-                    .map_err(|err| warn!("failed to mark file, which was not downloaded successfully, as corrupted: {}", err))
-                    .is_err();
-
-                let failed_to_remove = fs::remove_file(&entry.cache_path)
-                    .await
-                    .map_err(|err| {
-                        warn!(
-                            "failed to remove file, which was not downloaded successfully: {}",
-                            err
-                        )
-                    })
-                    .is_err();
-
-                let failed_to_remove_entry = api::remove_entry(&mut self.db, entry.id)
-                    .await
-                    .map_err(|err| {
-                        warn!(
-                        "failed to remove cache entry, which was not downloaded successfully: {}",
-                        err
-                    )
-                    })
-                    .is_err();
-
-                let corrupted = failed_to_update && failed_to_remove && failed_to_remove_entry;
-                if corrupted {
-                    // This is a very annoying error for user, because he can't do much about it.
-                    // User will have to remove the file manually.
-                    // Maintenance cannot fix this automatically because the file wasn't marked
-                    // as Corrupted or ToRemove and was not removed from cache directory.
-                    // FIXME: there must be something we could do here
-                    error!(
-                        "Failed to download URL: {}. \
-                        This error probably means that your cache state is now corrupted.\
-                        Try removing this URL manually using Carol CLI: carol files remove --force '{}'",
-                        entry.url, entry.url
-                    );
+                    // latest occured error will be thrown
+                    result
                 }
+            },
+        }
+    }
 
-                Err(err)
+    /// Query entry URL and store response body in target file.
+    /// Then set entry status to `Ready`.
+    async fn fetch_entry(&mut self, entry: &CacheEntry) -> Result<CacheEntry> {
+        let mut file = fs::File::create(&entry.cache_path).await?;
+
+        trace!("fetching {}", &entry.url);
+        let response = self
+            .reqwest_client
+            .get(&entry.url)
+            .send()
+            .await?
+            .error_for_status()?;
+        let code = response.status().as_u16();
+        if code != 200 {
+            // For responses with 2XX codes we probably only interested in 200.
+            return Err(Error::CustomError(format!(
+                "HTTP response status code {}",
+                code
+            )));
+        }
+        let mut stream = response.bytes_stream();
+        while let Some(chunk_result) = stream.next().await {
+            let chunk = chunk_result?;
+            file.write_all(&chunk).await?;
+        }
+        let updated_entry = api::update_status(&mut self.db, entry.id, FileStatus::Ready).await?;
+        Ok(updated_entry)
+    }
+
+    /// Clean-up entry: remove file from cache directory and remove cache entry from database.
+    ///
+    /// Returns errors if both operations failed.
+    async fn cleanup_entry(
+        &mut self,
+        entry: &CacheEntry,
+    ) -> StdResult<(), (IoError, DatabaseError)> {
+        let file_result = fs::remove_file(&entry.cache_path).await;
+        let entry_result = unsafe { api::delete_unsafe(&mut self.db, entry.id) }.await;
+        match (file_result, entry_result) {
+            (Err(file_error), Err(entry_error)) => {
+                // This is a severe clean-up error, which cannot be resolved automatically
+                // Corrupted file is left in a cache, but Carol has no identification about
+                // this entry being corrupt.
+                Err((file_error, entry_error))
             }
+            _ => Ok(()),
         }
     }
 
@@ -529,165 +519,237 @@ impl fmt::Debug for Client {
 /// Client fixtures. Helps in testing client-related code.
 #[cfg(test)]
 pub(crate) mod fixtures {
-    use crate::database::fixtures::CacheDatabaseFixture;
+    use super::ReqwestClient;
+    use crate::database::fixtures::{database, CacheDatabaseFixture};
+    use crate::database::models::{CacheEntry, NewCacheEntry};
     use crate::{Client, RetryPolicy};
+    use crate::{DateTime, FileStatus, Utc};
     use http_test_server::http::{Method, Status};
     use http_test_server::TestServer;
-    use std::path::PathBuf;
+    use rstest::fixture;
     use std::time::Duration;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
+    use tokio::fs;
+    use tracing::trace;
 
-    type Error = Box<dyn std::error::Error>;
+    pub const PORT: u16 = 44256;
+    pub const DEFAULT_PATH: &str = "/file.txt";
+    pub const DEFAULT_URL: &str = "http://localhost:44256/file.txt";
+    pub const DEFAULT_CONTENT: &str = "This is test file.";
 
-    /// Just keeps temp web server running and stops on drop.
-    /// Returns also host string e.g. `http://localhost:8080`.
-    pub fn setup_test_server() -> Result<(TestServer, String), Error> {
-        let server = TestServer::new()?;
-        let resource = server.create_resource("/file.txt");
+    /// Test HTTP server with a single resource on `http://localhost:44256/file.txt`.
+    #[fixture]
+    #[once]
+    pub fn test_server() -> TestServer {
+        let server = TestServer::new_with_port(PORT).unwrap();
+        let resource = server.create_resource(DEFAULT_PATH);
         resource
             .status(Status::OK)
             .method(Method::GET)
             .header("Content-Type", "text/plain")
-            .body("This is test file.");
-        let port = server.port();
-        let host = format!("http://localhost:{}", port);
-        Ok((server, host))
+            .body(DEFAULT_CONTENT);
+        server
     }
 
-    pub struct ClientFixture {
-        /// Holds test web server running and destroys it on drop.
-        #[allow(dead_code)]
-        web_server: Option<TestServer>,
-
-        /// Host string like `http://localhost:8080`.
-        pub host: String,
-
+    /// Fixture for initialized cache.
+    pub struct CacheFixture {
         /// Client with temp database and cache directory.
         pub client: Client,
 
         /// Hold cache directory and destroys it on drop.
-        #[allow(dead_code)]
-        tmp: TempDir,
-
-        /// Path to cache directory.
-        pub cache_dir: PathBuf,
+        pub cache_dir: TempDir,
 
         /// Database fixture.
         pub db: CacheDatabaseFixture,
     }
 
-    impl ClientFixture {
-        /// Create new client with empty cache.
-        pub async fn new() -> Result<Self, Error> {
-            let (web_server, host) = setup_test_server()?;
-            let db = CacheDatabaseFixture::new().await?;
-            let tmp = TempDir::new("carol.test.files").unwrap();
-            let cache_dir = tmp.path().to_path_buf();
-            let client = Client::builder(&db.db_path, &cache_dir)
-                .download_retry_policy(RetryPolicy::Fixed {
-                    number: 3,
-                    period: Duration::from_secs(1),
-                })
-                .build()
-                .await?;
-            Ok(Self {
-                web_server: Some(web_server),
-                host,
+    impl CacheFixture {
+        pub async fn new(
+            db: CacheDatabaseFixture,
+            retry_policy: RetryPolicy,
+            file_duration: Option<Duration>,
+            reqwest_client: Option<ReqwestClient>,
+        ) -> Self {
+            trace!("creating CacheFixture");
+            let cache_dir = tempfile::tempdir().unwrap();
+            let mut client_builder = Client::builder(&db.db_path, cache_dir.path());
+            if let Some(duration) = file_duration {
+                client_builder.default_file_duration(duration);
+            }
+            if let Some(client) = reqwest_client {
+                client_builder.reqwest_client(client);
+            }
+            client_builder.download_retry_policy(retry_policy);
+            trace!(
+                "building client in cache fixture from: {:?}",
+                &client_builder
+            );
+            let client = client_builder.build().await.unwrap();
+            CacheFixture {
                 client,
                 db,
-                tmp,
                 cache_dir,
-            })
+            }
         }
+    }
 
-        pub fn drop_web_server(&mut self) -> TestServer {
-            std::mem::take(&mut self.web_server).unwrap()
-        }
+    /// New empty cache.
+    #[fixture]
+    #[awt]
+    pub async fn cache(
+        #[default(RetryPolicy::None)] retry_policy: RetryPolicy,
+        #[default(None)] file_duration: Option<Duration>,
+        #[default(None)] reqwest_client: Option<ReqwestClient>,
+        #[future] database: CacheDatabaseFixture,
+    ) -> CacheFixture {
+        CacheFixture::new(database, retry_policy, file_duration, reqwest_client).await
+    }
+
+    pub type CacheWithFileFixture = (CacheFixture, CacheEntry);
+
+    /// New cache with a signle file stored.
+    #[fixture]
+    #[awt]
+    pub async fn cache_with_file(
+        #[default(DEFAULT_URL)] url: impl AsRef<str>,
+        #[default(FileStatus::Ready)] status: FileStatus,
+        #[default(None)] expires: Option<DateTime<Utc>>,
+        #[default(0)] ref_count: i32,
+        // This default value is sha256 of default url
+        #[default("1f8b6bd39e9e70cc634217b4686e25c715c82f3fe364c6454399e0aa60118ea4")]
+        filename: impl AsRef<str>,
+        #[default(DEFAULT_CONTENT)] content: impl AsRef<str>,
+        #[default(RetryPolicy::None)] retry_policy: RetryPolicy,
+        #[default(None)] file_duration: Option<Duration>,
+        #[default(None)] reqwest_client: Option<ReqwestClient>,
+        #[future] database: CacheDatabaseFixture,
+    ) -> CacheWithFileFixture {
+        trace!("IN cache_with_file");
+        let mut cache =
+            CacheFixture::new(database, retry_policy, file_duration, reqwest_client).await;
+        let cache_path = cache
+            .cache_dir
+            .path()
+            .join(filename.as_ref())
+            .to_str()
+            .unwrap()
+            .to_string();
+        fs::write(&cache_path, content.as_ref()).await.unwrap();
+        let entry = cache
+            .db
+            .insert_entry(NewCacheEntry {
+                url: url.as_ref().to_string(),
+                cache_path,
+                created: Utc::now(),
+                expires,
+                status,
+                ref_count,
+            })
+            .await;
+        (cache, entry)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::fixtures::ClientFixture;
-    use super::*;
-    use crate::errors::{DatabaseError, RemoveErrorReason};
+    use super::fixtures::{
+        cache, cache_with_file, test_server, CacheFixture, CacheWithFileFixture, DEFAULT_CONTENT,
+        DEFAULT_URL,
+    };
+    use super::Client;
+    use crate::database::api;
+    use crate::{DateTime, FileStatus, RetryPolicy, Utc};
+    use http_test_server::TestServer;
+    use rstest::rstest;
     use std::time::Duration;
-    use tempdir::TempDir;
     use tokio::fs;
+    use tracing::trace;
     use tracing_test::traced_test;
 
     #[tokio::test]
     #[traced_test]
     async fn test_init_new_cache() {
-        let tmp_database = TempDir::new("carol.test.database").unwrap();
+        let tmp_database = tempfile::tempdir().unwrap();
         let database = tmp_database.path().join("carol.sqlite");
         let database_path = database.as_os_str().to_str().unwrap().to_string();
 
-        let tmp_cache_dir = TempDir::new("carol.test.database").unwrap();
+        let tmp_cache_dir = tempfile::tempdir().unwrap();
 
         Client::init(&database_path, tmp_cache_dir.path())
             .await
             .expect("initialize new cache");
     }
 
+    #[rstest]
     #[tokio::test]
     #[traced_test]
-    async fn test_connect_to_existing_cache() {
-        let fixture = ClientFixture::new().await.unwrap();
-
-        Client::init(&fixture.db.db_path, &fixture.cache_dir)
+    #[awt]
+    async fn test_connect_to_existing_cache(#[future] cache: CacheFixture) {
+        trace!("begin test");
+        Client::init(&cache.db.db_path, &cache.cache_dir)
             .await
             .expect("connect to existing cache");
     }
 
+    #[rstest]
     #[tokio::test]
     #[traced_test]
-    async fn test_get() {
-        let fixture = ClientFixture::new().await.unwrap();
-        let mut client = fixture.client;
-        let url = format!("{}/file.txt", &fixture.host);
-        let file = client.get(&url).await.expect("get file from URL");
+    #[awt]
+    async fn test_get(
+        #[future] mut cache: CacheFixture,
+        #[allow(unused)] test_server: &TestServer,
+    ) {
+        trace!("begin test");
+        let file = cache
+            .client
+            .get(DEFAULT_URL)
+            .await
+            .expect("get file from URL");
         assert_eq!(
             file.status().await.expect("get file status"),
             FileStatus::Ready
         );
-        assert_eq!(file.url(), url);
+        assert_eq!(file.url(), DEFAULT_URL);
         let content = fs::read_to_string(file.cache_path())
             .await
             .expect("read downloaded file");
-        assert_eq!(content, "This is test file.");
+        assert_eq!(content, DEFAULT_CONTENT);
+        let entry = api::get_entry(&mut cache.db.conn, file.id).await.unwrap();
+        assert_eq!(entry.ref_count, 1);
+        file.release().await.unwrap();
     }
 
+    #[rstest]
     #[tokio::test]
     #[traced_test]
-    async fn test_get_not_re_downloading() {
-        let mut fixture = ClientFixture::new().await.unwrap();
-        let client = &mut fixture.client;
-
-        let url = format!("{}/file.txt", &fixture.host);
-        let first_file = client
-            .get(&url)
+    #[awt]
+    async fn test_get_not_re_downloading(#[future] cache_with_file: CacheWithFileFixture) {
+        trace!("begin test");
+        let (mut cache, entry) = cache_with_file;
+        let file = cache
+            .client
+            .get(DEFAULT_URL)
             .await
-            .expect("get file from URL first time");
-
-        // drop server to ensure next time nothing will be downloaded
-        fixture.drop_web_server();
-        assert!(reqwest::get(&url).await.is_err());
-
-        let client = &mut fixture.client;
-        let second_file = client
-            .get(&url)
+            .expect("get existing file from URL");
+        assert_eq!(file.id, entry.id);
+        let content = fs::read_to_string(file.cache_path())
             .await
-            .expect("get file from URL second time");
-        assert_eq!(first_file.id, second_file.id);
+            .expect("read existing file");
+        assert_eq!(content, DEFAULT_CONTENT);
     }
 
+    #[rstest]
     #[tokio::test]
     #[traced_test]
-    async fn test_downloading_retry() {
-        let mut fixture = ClientFixture::new().await.unwrap();
-        let url = format!("{}/new_file.txt", &fixture.host);
-        let test_server = fixture.drop_web_server();
+    #[awt]
+    async fn test_downloading_retry(
+        #[future]
+        #[with(RetryPolicy::Fixed { number: 3, period: Duration::from_secs(1) })]
+        cache: CacheFixture,
+        test_server: &TestServer,
+    ) {
+        trace!("begin test");
+        let url = format!("http://localhost:{}/new_file.txt", test_server.port());
 
         // Create resource after 2500 millisecs
         // Give client time to fail 2 times before providing resource
@@ -704,7 +766,7 @@ mod tests {
         };
 
         let get_resource = async || {
-            let mut client = fixture.client;
+            let mut client = cache.client;
             let file = client
                 .get(&url)
                 .await
@@ -728,130 +790,114 @@ mod tests {
         )));
     }
 
+    #[rstest]
+    #[case::unused_file(0)]
+    #[should_panic(expected = "remove URL from cache: DatabaseError(RemoveError(UsedFile))")]
+    #[case::used_file(1)]
     #[tokio::test]
     #[traced_test]
-    async fn test_remove() {
-        let fixture = ClientFixture::new().await.unwrap();
-        let mut client = fixture.client;
-        let url = format!("{}/file.txt", &fixture.host);
-        let file = client.get(&url).await.expect("get file from URL");
-        file.release().await.expect("release file");
-        client.remove(&url).await.expect("remove URL from cache");
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn test_remove_failure() {
-        let fixture = ClientFixture::new().await.unwrap();
-        let mut client = fixture.client;
-        let url = format!("{}/file.txt", &fixture.host);
-        let file = client.get(&url).await.expect("get file from URL");
-        let result = client.remove(&url).await;
-        assert!(matches!(
-            result,
-            Err(Error::DatabaseError(DatabaseError::RemoveError(
-                RemoveErrorReason::UsedFile
-            )))
-        ));
-        file.release().await.unwrap();
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn test_set_expires() {
-        let fixture = ClientFixture::new().await.unwrap();
-        let mut client = fixture.client;
-        let url = format!("{}/file.txt", &fixture.host);
-        client.get(&url).await.unwrap();
+    #[awt]
+    async fn test_remove(
+        #[allow(unused)]
+        #[case]
+        ref_count: i32,
+        #[future]
+        #[with(DEFAULT_URL, FileStatus::Ready, None, ref_count)]
+        cache_with_file: CacheWithFileFixture,
+    ) {
+        trace!("begin test");
+        let (cache, _) = cache_with_file;
+        let mut client = cache.client;
         client
-            .set_expires(&url, DateTime::<Utc>::MAX_UTC)
+            .remove(DEFAULT_URL)
+            .await
+            .expect("remove URL from cache");
+    }
+
+    #[rstest]
+    #[tokio::test]
+    #[traced_test]
+    #[awt]
+    async fn test_set_expires(#[future] cache_with_file: CacheWithFileFixture) {
+        trace!("begin test");
+        let (mut cache, entry) = cache_with_file;
+        let mut client = cache.client;
+        client
+            .set_expires(DEFAULT_URL, DateTime::<Utc>::MAX_UTC)
             .await
             .expect("set expiration timestamp");
-        let file = client.get(&url).await.unwrap();
-        let expires_at = file.expires().await.expect("get expiration timestamp");
-        assert_eq!(expires_at, Some(DateTime::<Utc>::MAX_UTC));
+        let updated_entry = api::get_entry(&mut cache.db.conn, entry.id).await.unwrap();
+        assert_eq!(updated_entry.expires, Some(DateTime::<Utc>::MAX_UTC));
     }
 
+    #[rstest]
     #[tokio::test]
     #[traced_test]
-    async fn test_schedule_for_removal() {
-        let fixture = ClientFixture::new().await.unwrap();
-        let mut client = fixture.client;
-        let url = format!("{}/file.txt", &fixture.host);
-        client.get(&url).await.unwrap();
+    #[awt]
+    async fn test_schedule_for_removal(#[future] cache_with_file: CacheWithFileFixture) {
+        trace!("begin test");
+        let (mut cache, entry) = cache_with_file;
+        let mut client = cache.client;
         client
-            .schedule_for_removal(&url)
+            .schedule_for_removal(DEFAULT_URL)
             .await
             .expect("schedule URL for removal");
-        let file = client.get(&url).await.unwrap();
-        let status = file.status().await.expect("get file status");
-        assert_eq!(status, FileStatus::ToRemove);
+        let updated_entry = api::get_entry(&mut cache.db.conn, entry.id).await.unwrap();
+        assert_eq!(updated_entry.status, FileStatus::ToRemove);
     }
 
+    #[rstest]
     #[tokio::test]
     #[traced_test]
-    async fn test_update() {
-        let fixture = ClientFixture::new().await.unwrap();
-        let mut client = fixture.client;
-        let url = format!("{}/file.txt", &fixture.host);
-        let old_file = client.get(&url).await.unwrap();
-        let old_timestamp = *old_file.created();
-        // release file to allow updating it
-        old_file.release().await.unwrap();
-
-        let new_file = client.update(&url).await.expect("update cache entry");
-        let new_timestamp = new_file.created();
-        assert!(new_timestamp > &old_timestamp);
+    #[awt]
+    async fn test_update(
+        #[future] cache_with_file: CacheWithFileFixture,
+        #[allow(unused)] test_server: &TestServer,
+    ) {
+        trace!("begin test");
+        let (mut cache, entry) = cache_with_file;
+        let mut client = cache.client;
+        client
+            .update(&DEFAULT_URL)
+            .await
+            .expect("update cache entry");
+        let updated_entry = api::get_entry(&mut cache.db.conn, entry.id).await.unwrap();
+        assert!(updated_entry.created > entry.created);
     }
 
+    #[rstest]
+    #[case::wait_enough_time(Duration::from_secs(5))]
+    #[should_panic(expected = "wait for URL released: TimeoutExceeded")]
+    #[case::wait_not_enough_time(Duration::from_secs(1))]
     #[tokio::test]
     #[traced_test]
-    async fn test_wait_url_released() {
-        let fixture = ClientFixture::new().await.unwrap();
-        let mut client = fixture.client;
-        let url = format!("{}/file.txt", &fixture.host);
-        let file = client.get(&url).await.expect("get file from URL");
+    #[awt]
+    async fn test_wait_url_released(
+        #[with(DEFAULT_URL, FileStatus::Ready, None, 1)]
+        #[future]
+        cache_with_file: CacheWithFileFixture,
+        #[case] wait_time: Duration,
+    ) {
+        trace!("begin test");
+        let (mut cache, entry) = cache_with_file;
+        let mut client = cache.client;
 
-        // Release file after 1 second
-        let release_file = async || {
-            tokio::time::sleep(Duration::from_secs(1)).await;
-            file.release().await.unwrap();
+        // Release file after 3 seconds
+        let mut release_file = async || {
+            tokio::time::sleep(Duration::from_secs(3)).await;
+            api::decrement_ref(&mut cache.db.conn, entry.id)
+                .await
+                .unwrap();
         };
 
         // Wait 5 seconds for URL to become free
         let mut wait_for_url_released = async || {
             client
-                .wait_url_released(&url, Duration::from_secs(5))
+                .wait_url_released(DEFAULT_URL, wait_time)
                 .await
                 .expect("wait for URL released");
         };
 
         tokio::join!(release_file(), wait_for_url_released());
     }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn test_wait_url_released_failure() {
-        let fixture = ClientFixture::new().await.unwrap();
-        let mut client = fixture.client;
-        let url = format!("{}/file.txt", &fixture.host);
-        let file = client.get(&url).await.expect("get file from URL");
-
-        // Release file after 2 second
-        let release_file = async move || {
-            tokio::time::sleep(Duration::from_secs(2)).await;
-            file.release().await.unwrap();
-        };
-
-        // Wait 1 seconds for URL to become free (should fail)
-        let mut wait_for_url_released = async || {
-            let result = client.wait_url_released(&url, Duration::from_secs(1)).await;
-            assert!(matches!(dbg!(result), Err(Error::TimeoutExceeded)));
-        };
-
-        tokio::join!(release_file(), wait_for_url_released());
-    }
-
-    // TODO: tests granularity:
-    //       don't mix up methods in tests, prepare proper cache state manually instead
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -518,6 +518,7 @@ impl fmt::Debug for Client {
 
 /// Client fixtures. Helps in testing client-related code.
 #[cfg(test)]
+#[allow(clippy::too_many_arguments)]
 pub(crate) mod fixtures {
     use super::ReqwestClient;
     use crate::database::fixtures::{database, CacheDatabaseFixture};

--- a/src/database/database_stresstest.rs
+++ b/src/database/database_stresstest.rs
@@ -7,7 +7,6 @@ use crate::database::{self, api, Connection};
 use crate::errors::DatabaseError;
 use crate::FileStatus;
 use std::sync::Arc;
-use tempdir::TempDir;
 use tokio::sync::RwLock;
 use tokio::task::JoinSet;
 use tracing_test::traced_test;
@@ -26,7 +25,7 @@ async fn test_cache_database_stress_testing() {
     const COUNT: usize = 3000;
 
     // testing on new empty database
-    let tmp = TempDir::new("carol.test").unwrap();
+    let tmp = tempfile::tempdir().unwrap();
     let db_path = tmp.path().join("carol.sqlite");
 
     database::run_migrations(db_path.as_os_str().to_str().unwrap())

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -21,6 +21,7 @@ pub mod schema;
 
 #[cfg(feature = "stresstest")]
 #[cfg(test)]
+#[cfg(not(tarpaulin))]
 mod database_stresstest;
 
 /// Inner SQLite connection type.

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -135,12 +135,11 @@ pub async fn run_migrations(database_url: &str) -> DatabaseResult<()> {
 #[cfg(test)]
 pub(crate) mod fixtures {
     use super::models::{CacheEntry, NewCacheEntry};
-    use super::*;
-    use crate::errors::NonUtf8PathError;
+    use super::{api, establish_connection, run_migrations, Connection};
     use crate::{DateTime, FileStatus, Utc};
-    use tempdir::TempDir;
-
-    type Error = Box<dyn std::error::Error>;
+    use rstest::fixture;
+    use tempfile::TempDir;
+    use tracing::trace;
 
     /// Fixture which creates new database as temp file.
     /// Removes database on drop.
@@ -153,7 +152,7 @@ pub(crate) mod fixtures {
         pub db_path: String,
 
         /// Database connection.
-        pub db: Connection,
+        pub conn: Connection,
     }
 
     impl CacheDatabaseFixture {
@@ -169,61 +168,64 @@ pub(crate) mod fixtures {
             }
         }
 
-        /// Just an example entry of database which will be created from [`Self::default_new_entry`].
-        pub fn default_entry() -> CacheEntry {
-            CacheEntry {
-                id: 1,
-                url: "http://localhost".to_string(),
-                cache_path: "/var/cache/file".to_string(),
-                created: DateTime::<Utc>::MIN_UTC,
-                expires: None,
-                status: FileStatus::Pending,
-                ref_count: 0,
+        /// Create new empty temp database.
+        pub async fn new() -> Self {
+            trace!("creating CacheDatabaseFixture");
+            let tmp = tempfile::tempdir().unwrap();
+            let db_path = tmp.path().join("carol.sqlite");
+            let db_path = db_path.to_str().unwrap().to_string();
+            run_migrations(&db_path).await.unwrap();
+            let db = establish_connection(&db_path).await.unwrap();
+            Self {
+                tmp,
+                db_path,
+                conn: db,
             }
         }
 
-        /// Create new empty temp database.
-        pub async fn new() -> Result<Self, Error> {
-            let tmp = TempDir::new("carol.test.database")?;
-            let db_path = tmp.path().join("carol.sqlite");
-            let db_path = db_path
-                .as_os_str()
-                .to_str()
-                .ok_or(NonUtf8PathError)?
-                .to_string();
-            run_migrations(&db_path).await?;
-            let db = establish_connection(&db_path).await?;
-            Ok(Self { tmp, db_path, db })
+        /// Insert new entry into current database fixture.
+        pub async fn insert_entry(&mut self, new_entry: NewCacheEntry) -> CacheEntry {
+            trace!(
+                "inserting entry into CacheDatabaseFixture: {:?}",
+                &new_entry
+            );
+            let entry = unsafe { api::insert_unsafe(&mut self.conn, new_entry).await.unwrap() };
+            trace!("CacheDatabaseFixture now contains: {:?}", &entry);
+            entry
         }
+    }
 
-        /// Create new temp database with given entry.
-        /// Returns also primary key of that entry.
-        pub async fn new_with_entry(entry: NewCacheEntry) -> Result<(Self, i32), Error> {
-            let mut fixture = Self::new().await?;
-            let pk = unsafe { api::insert_unsafe(&mut fixture.db, entry).await? }.id;
-            Ok((fixture, pk))
-        }
+    // TODO: use in-memory database for fixture
 
-        /// Create new temp database with default entry (from [`Self::default_entry`]).
-        /// Returns also primary key of that entry.
-        pub async fn new_with_default_entry() -> Result<(Self, i32), Error> {
-            Self::new_with_entry(Self::default_new_entry()).await
-        }
+    /// Create new empty database.
+    #[fixture]
+    pub(crate) async fn database() -> CacheDatabaseFixture {
+        CacheDatabaseFixture::new().await
+    }
+
+    /// Create new database with a single entry.
+    #[fixture]
+    pub(crate) async fn database_with_single_entry(
+        #[default(CacheDatabaseFixture::default_new_entry())] new_entry: NewCacheEntry,
+    ) -> (CacheDatabaseFixture, CacheEntry) {
+        let mut database = database().await;
+        let entry = database.insert_entry(new_entry).await;
+        (database, entry)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::fixtures::CacheDatabaseFixture;
-    use super::*;
+    use super::establish_connection;
+    use super::fixtures::{database, CacheDatabaseFixture};
     use crate::errors::NonUtf8PathError;
-    use tempdir::TempDir;
+    use rstest::rstest;
     use tracing_test::traced_test;
 
     #[tokio::test]
     #[traced_test]
     async fn test_create_new_database() {
-        let tmp = TempDir::new("carol.test").unwrap();
+        let tmp = tempfile::tempdir().unwrap();
         let db_path = tmp.path().join("carol.sqlite");
         let db_path_str = db_path
             .as_os_str()
@@ -236,12 +238,12 @@ mod tests {
             .expect("create new database");
     }
 
+    #[rstest]
     #[tokio::test]
     #[traced_test]
-    async fn test_connect_to_existing_database() {
-        let db = CacheDatabaseFixture::new().await.unwrap();
-
-        establish_connection(&db.db_path)
+    #[awt]
+    async fn test_connect_to_existing_database(#[future] database: CacheDatabaseFixture) {
+        establish_connection(&database.db_path)
             .await
             .expect("connect to existing database");
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,10 @@
 //! Error types.
 
+use std::fmt;
+use std::io::Error as IoError;
+
 use diesel::result::DatabaseErrorKind;
+use eyre::eyre;
 
 #[doc(no_inline)]
 pub use diesel::result::{ConnectionError, Error as DieselError};
@@ -60,7 +64,7 @@ pub enum Error {
 
     /// Some I/O operation failed
     #[error("I/O error")]
-    IoError(#[from] std::io::Error),
+    IoError(#[from] IoError),
 
     /// Error during building reqwest client
     #[error("failed to build reqwest client")]
@@ -78,6 +82,9 @@ pub enum Error {
     #[error("awaited file failed to download")]
     AwaitingError,
 
+    #[error(transparent)]
+    CleanUpError(Box<CleanUpError>),
+
     /// Occurs when attempted to perform some action on URL which is not cached.
     #[error("URL '{0}' is not cached")]
     UrlNotCached(String),
@@ -92,6 +99,47 @@ pub enum Error {
 
     #[error(transparent)]
     NonUtf8PathError(#[from] NonUtf8PathError),
+}
+
+/// Failed to properly clean-up cache after download failure.
+///
+/// Both errors `remove_file_error` and `database_error` happened at the same time.
+///
+/// If this is returned from [`Client::get`][crate::Client::get],
+/// this most likely means that cache is not in an invalid state
+/// and needs to be fixed manually. Because of that, this error should be
+/// treated **as severe**.
+#[derive(Debug)]
+pub struct CleanUpError {
+    /// Error happened during file removal
+    pub remove_file_error: IoError,
+
+    /// Error happened during cache entry removal
+    pub database_error: DatabaseError,
+
+    /// Original downloading error, which caused the clean-up
+    pub download_error: Error,
+}
+
+impl fmt::Display for CleanUpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "failed to clean-up cache after download failed:\n\
+        - removing corrupted file failed: {}\n\
+        - removing cache entry failed: {}\n\
+        This error probably means that your cache is now contains corrupted file.\n\
+        Consider using Carol CLI to remove the entry manually.",
+            eyre!("{:#}", &self.remove_file_error),
+            eyre!("{:#}", &self.database_error)
+        )
+    }
+}
+
+impl std::error::Error for CleanUpError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.download_error)
+    }
 }
 
 /// Non UTF-8 symbol in path.

--- a/src/maintenance/cleaner.rs
+++ b/src/maintenance/cleaner.rs
@@ -83,75 +83,79 @@ impl<'c> CacheCleaner<'c> {
 // TODO: Garbage collector may run a pool of clients to perform removals asynchronously.
 //       For now files are removed sequentially, because &mut Client cannot be shared.
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use crate::client::fixtures::ClientFixture;
-//     use crate::{DateTime, Utc};
-//     use tracing_test::traced_test;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::fixtures::{cache_with_file, CacheWithFileFixture, DEFAULT_URL};
+    use crate::database::api;
+    use crate::{DateTime, Utc};
+    use rstest::rstest;
+    use tracing_test::traced_test;
+    use tracing::trace;
 
-//     #[tokio::test]
-//     #[traced_test]
-//     async fn test_schedule_for_removal() {
-//         let fixture = ClientFixture::new().await.unwrap();
-//         let mut client = fixture.client;
+    #[rstest]
+    #[tokio::test]
+    #[traced_test]
+    #[awt]
+    async fn test_schedule_for_removal(
+        #[future]
+        #[with(DEFAULT_URL, FileStatus::Ready, Some(DateTime::<Utc>::MIN_UTC))]
+        cache_with_file: CacheWithFileFixture,
+    ) {
+        trace!("begin test");
+        let (mut cache, entry) = cache_with_file;
+        let mut client = cache.client;
 
-//         let url = format!("{}/file.txt", &fixture.host);
-//         client.get(&url).await.unwrap();
-//         client
-//             .set_expires(&url, DateTime::<Utc>::MIN_UTC)
-//             .await
-//             .unwrap();
+        let mut cleaner = CacheCleaner::new(&mut client);
+        cleaner
+            .schedule_for_removal()
+            .await
+            .expect("schedule for removal all expired files");
 
-//         let mut cleaner = CacheCleaner::new(&mut client);
-//         cleaner
-//             .schedule_for_removal()
-//             .await
-//             .expect("schedule for removal");
+        let entry = api::get_entry(&mut cache.db.conn, entry.id).await.unwrap();
+        assert_eq!(entry.status, FileStatus::ToRemove);
+    }
 
-//         let status = client.get(&url).await.unwrap().status().await.unwrap();
-//         assert_eq!(status, FileStatus::ToRemove);
-//     }
+    #[rstest]
+    #[tokio::test]
+    #[traced_test]
+    #[awt]
+    async fn test_remove(
+        #[future]
+        #[with(DEFAULT_URL, FileStatus::ToRemove)]
+        cache_with_file: CacheWithFileFixture,
+    ) {
+        trace!("begin test");
+        let (mut cache, _) = cache_with_file;
+        let mut client = cache.client;
 
-//     #[tokio::test]
-//     #[traced_test]
-//     async fn test_remove() {
-//         let fixture = ClientFixture::new().await.unwrap();
-//         let mut client = fixture.client;
+        let mut cleaner = CacheCleaner::new(&mut client);
+        cleaner
+            .remove()
+            .await
+            .expect("remove files with 'ToRemove' status");
 
-//         let url = format!("{}/file.txt", &fixture.host);
-//         let file = client.get(&url).await.unwrap();
-//         file.release().await.unwrap();
-//         client.schedule_for_removal(&url).await.unwrap();
+        let entries = api::get_all(&mut cache.db.conn).await.unwrap();
+        assert!(entries.is_empty());
+    }
 
-//         let mut cleaner = CacheCleaner::new(&mut client);
-//         cleaner
-//             .remove()
-//             .await
-//             .expect("remove files with 'ToRemove' status");
+    #[rstest]
+    #[tokio::test]
+    #[traced_test]
+    #[awt]
+    async fn test_run_once(
+        #[future]
+        #[with(DEFAULT_URL, FileStatus::Ready, Some(DateTime::<Utc>::MIN_UTC))]
+        cache_with_file: CacheWithFileFixture,
+    ) {
+        trace!("begin test");
+        let (mut cache, _) = cache_with_file;
+        let mut client = cache.client;
 
-//         let maybe_file = client.find(&url).await.unwrap();
-//         assert!(maybe_file.is_none());
-//     }
+        let mut cleaner = CacheCleaner::new(&mut client);
+        cleaner.run_once().await.expect("run cache cleaner");
 
-//     #[tokio::test]
-//     #[traced_test]
-//     async fn test_run_once() {
-//         let fixture = ClientFixture::new().await.unwrap();
-//         let mut client = fixture.client;
-
-//         let url = format!("{}/file.txt", &fixture.host);
-//         let file = client.get(&url).await.unwrap();
-//         file.release().await.unwrap();
-//         client
-//             .set_expires(&url, DateTime::<Utc>::MIN_UTC)
-//             .await
-//             .unwrap();
-
-//         let mut cleaner = CacheCleaner::new(&mut client);
-//         cleaner.run_once().await.expect("run cache cleaner");
-
-//         let maybe_file = client.find(&url).await.unwrap();
-//         assert!(maybe_file.is_none());
-//     }
-// }
+        let entries = api::get_all(&mut cache.db.conn).await.unwrap();
+        assert!(entries.is_empty());
+    }
+}

--- a/src/maintenance/cleaner.rs
+++ b/src/maintenance/cleaner.rs
@@ -90,8 +90,8 @@ mod tests {
     use crate::database::api;
     use crate::{DateTime, Utc};
     use rstest::rstest;
-    use tracing_test::traced_test;
     use tracing::trace;
+    use tracing_test::traced_test;
 
     #[rstest]
     #[tokio::test]

--- a/src/maintenance/cleaner.rs
+++ b/src/maintenance/cleaner.rs
@@ -83,75 +83,75 @@ impl<'c> CacheCleaner<'c> {
 // TODO: Garbage collector may run a pool of clients to perform removals asynchronously.
 //       For now files are removed sequentially, because &mut Client cannot be shared.
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::client::fixtures::ClientFixture;
-    use crate::{DateTime, Utc};
-    use tracing_test::traced_test;
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use crate::client::fixtures::ClientFixture;
+//     use crate::{DateTime, Utc};
+//     use tracing_test::traced_test;
 
-    #[tokio::test]
-    #[traced_test]
-    async fn test_schedule_for_removal() {
-        let fixture = ClientFixture::new().await.unwrap();
-        let mut client = fixture.client;
+//     #[tokio::test]
+//     #[traced_test]
+//     async fn test_schedule_for_removal() {
+//         let fixture = ClientFixture::new().await.unwrap();
+//         let mut client = fixture.client;
 
-        let url = format!("{}/file.txt", &fixture.host);
-        client.get(&url).await.unwrap();
-        client
-            .set_expires(&url, DateTime::<Utc>::MIN_UTC)
-            .await
-            .unwrap();
+//         let url = format!("{}/file.txt", &fixture.host);
+//         client.get(&url).await.unwrap();
+//         client
+//             .set_expires(&url, DateTime::<Utc>::MIN_UTC)
+//             .await
+//             .unwrap();
 
-        let mut cleaner = CacheCleaner::new(&mut client);
-        cleaner
-            .schedule_for_removal()
-            .await
-            .expect("schedule for removal");
+//         let mut cleaner = CacheCleaner::new(&mut client);
+//         cleaner
+//             .schedule_for_removal()
+//             .await
+//             .expect("schedule for removal");
 
-        let status = client.get(&url).await.unwrap().status().await.unwrap();
-        assert_eq!(status, FileStatus::ToRemove);
-    }
+//         let status = client.get(&url).await.unwrap().status().await.unwrap();
+//         assert_eq!(status, FileStatus::ToRemove);
+//     }
 
-    #[tokio::test]
-    #[traced_test]
-    async fn test_remove() {
-        let fixture = ClientFixture::new().await.unwrap();
-        let mut client = fixture.client;
+//     #[tokio::test]
+//     #[traced_test]
+//     async fn test_remove() {
+//         let fixture = ClientFixture::new().await.unwrap();
+//         let mut client = fixture.client;
 
-        let url = format!("{}/file.txt", &fixture.host);
-        let file = client.get(&url).await.unwrap();
-        file.release().await.unwrap();
-        client.schedule_for_removal(&url).await.unwrap();
+//         let url = format!("{}/file.txt", &fixture.host);
+//         let file = client.get(&url).await.unwrap();
+//         file.release().await.unwrap();
+//         client.schedule_for_removal(&url).await.unwrap();
 
-        let mut cleaner = CacheCleaner::new(&mut client);
-        cleaner
-            .remove()
-            .await
-            .expect("remove files with 'ToRemove' status");
+//         let mut cleaner = CacheCleaner::new(&mut client);
+//         cleaner
+//             .remove()
+//             .await
+//             .expect("remove files with 'ToRemove' status");
 
-        let maybe_file = client.find(&url).await.unwrap();
-        assert!(maybe_file.is_none());
-    }
+//         let maybe_file = client.find(&url).await.unwrap();
+//         assert!(maybe_file.is_none());
+//     }
 
-    #[tokio::test]
-    #[traced_test]
-    async fn test_run_once() {
-        let fixture = ClientFixture::new().await.unwrap();
-        let mut client = fixture.client;
+//     #[tokio::test]
+//     #[traced_test]
+//     async fn test_run_once() {
+//         let fixture = ClientFixture::new().await.unwrap();
+//         let mut client = fixture.client;
 
-        let url = format!("{}/file.txt", &fixture.host);
-        let file = client.get(&url).await.unwrap();
-        file.release().await.unwrap();
-        client
-            .set_expires(&url, DateTime::<Utc>::MIN_UTC)
-            .await
-            .unwrap();
+//         let url = format!("{}/file.txt", &fixture.host);
+//         let file = client.get(&url).await.unwrap();
+//         file.release().await.unwrap();
+//         client
+//             .set_expires(&url, DateTime::<Utc>::MIN_UTC)
+//             .await
+//             .unwrap();
 
-        let mut cleaner = CacheCleaner::new(&mut client);
-        cleaner.run_once().await.expect("run cache cleaner");
+//         let mut cleaner = CacheCleaner::new(&mut client);
+//         cleaner.run_once().await.expect("run cache cleaner");
 
-        let maybe_file = client.find(&url).await.unwrap();
-        assert!(maybe_file.is_none());
-    }
-}
+//         let maybe_file = client.find(&url).await.unwrap();
+//         assert!(maybe_file.is_none());
+//     }
+// }

--- a/src/maintenance/mod.rs
+++ b/src/maintenance/mod.rs
@@ -252,108 +252,61 @@ impl<'c> MaintenanceRunner<'c> {
 // TODO: Asynchronously handle files in maintenance runner.
 //       Right now we synchronously iterate over files, which is not efficient.
 
-// #[cfg(test)]
-// mod fixtures {
-//     use super::{MaintenanceOpts, MaintenanceRunner};
-//     use crate::client::fixtures::ClientFixture;
-//     use crate::database::api;
-//     use crate::FileStatus;
-//     use tokio::fs;
+#[cfg(test)]
+mod tests {
+    use super::{MaintenanceOpts, MaintenanceRunner};
+    use crate::client::fixtures::{cache_with_file, CacheWithFileFixture, DEFAULT_URL};
+    use crate::client::Client;
+    use crate::database::api;
+    use crate::FileStatus;
+    use rstest::rstest;
+    use tokio::fs;
+    use tracing::trace;
+    use tracing_test::traced_test;
 
-//     type Error = Box<dyn std::error::Error>;
+    fn get_runner(client: &mut Client) -> MaintenanceRunner {
+        MaintenanceRunner::new(client, MaintenanceOpts::builder().build().unwrap())
+    }
 
-//     pub struct CarolFixture {
-//         pub client: ClientFixture,
-//     }
+    #[rstest]
+    #[tokio::test]
+    #[traced_test]
+    #[awt]
+    async fn test_find_corrupted_cache_entries(#[future] cache_with_file: CacheWithFileFixture) {
+        trace!("begin test");
+        let (mut cache, entry) = cache_with_file;
+        let mut runner = get_runner(&mut cache.client);
 
-//     impl CarolFixture {
-//         pub async fn new() -> Result<Self, Error> {
-//             Ok(Self {
-//                 client: ClientFixture::new().await?,
-//             })
-//         }
+        fs::remove_file(&entry.cache_path).await.unwrap();
 
-//         pub fn runner(&mut self) -> MaintenanceRunner {
-//             MaintenanceRunner::new(
-//                 &mut self.client.client,
-//                 MaintenanceOpts::builder().build().unwrap(),
-//             )
-//         }
+        runner
+            .find_corrupted_cache_entries()
+            .await
+            .expect("find corrupted cache entries");
 
-//         pub async fn with_entry(mut self) -> Result<Self, Error> {
-//             let url = format!("{}/file.txt", &self.client.host);
-//             let file = self.client.client.get(&url).await?;
-//             file.release().await?;
-//             Ok(self)
-//         }
+        let entry = api::get_entry(&mut cache.db.conn, entry.id).await.unwrap();
+        assert_eq!(entry.status, FileStatus::Corrupted);
+    }
 
-//         pub async fn remove_file(mut self) -> Result<Self, Error> {
-//             self = self.with_entry().await?;
-//             let url = format!("{}/file.txt", &self.client.host);
-//             let file = self.client.client.find(&url).await?.unwrap();
-//             fs::remove_file(file.cache_path()).await?;
-//             file.release().await?;
-//             Ok(self)
-//         }
+    #[rstest]
+    #[tokio::test]
+    #[traced_test]
+    #[awt]
+    async fn test_remove_corrupted_cache_entries(
+        #[future]
+        #[with(DEFAULT_URL, FileStatus::Corrupted)]
+        cache_with_file: CacheWithFileFixture,
+    ) {
+        trace!("begin test");
+        let (mut cache, _) = cache_with_file;
+        let mut runner = get_runner(&mut cache.client);
 
-//         pub async fn with_corrupted_entry(mut self) -> Result<Self, Error> {
-//             self = self.with_entry().await?;
-//             let url = format!("{}/file.txt", &self.client.host);
-//             let pk = api::get_by_url(&mut self.client.client.db, &url)
-//                 .await?
-//                 .unwrap()
-//                 .id;
-//             api::update_status(&mut self.client.client.db, pk, FileStatus::Corrupted).await?;
-//             Ok(self)
-//         }
-//     }
-// }
+        runner
+            .remove_corrupted_entries()
+            .await
+            .expect("remove corrupted cache entries");
 
-// #[cfg(test)]
-// mod tests {
-//     use super::fixtures::CarolFixture;
-//     use crate::FileStatus;
-//     use tracing_test::traced_test;
-
-//     #[tokio::test]
-//     #[traced_test]
-//     async fn test_find_corrupted_cache_entries() {
-//         let mut fixture = CarolFixture::new()
-//             .await
-//             .unwrap()
-//             .remove_file()
-//             .await
-//             .unwrap();
-//         let mut runner = fixture.runner();
-
-//         runner
-//             .find_corrupted_cache_entries()
-//             .await
-//             .expect("find corrupted cache entries");
-
-//         let url = format!("{}/file.txt", &fixture.client.host);
-//         let file = fixture.client.client.get(&url).await.unwrap();
-//         assert_eq!(file.status().await.unwrap(), FileStatus::Corrupted);
-//     }
-
-//     #[tokio::test]
-//     #[traced_test]
-//     async fn test_remove_corrupted_cache_entries() {
-//         let mut fixture = CarolFixture::new()
-//             .await
-//             .unwrap()
-//             .with_corrupted_entry()
-//             .await
-//             .unwrap();
-//         let mut runner = fixture.runner();
-
-//         runner
-//             .remove_corrupted_entries()
-//             .await
-//             .expect("remove corrupted cache entries");
-
-//         let url = format!("{}/file.txt", &fixture.client.host);
-//         let file = fixture.client.client.find(&url).await.unwrap();
-//         assert!(file.is_none());
-//     }
-// }
+        let entrirs = api::get_all(&mut cache.db.conn).await.unwrap();
+        assert!(entrirs.is_empty());
+    }
+}

--- a/src/maintenance/mod.rs
+++ b/src/maintenance/mod.rs
@@ -49,6 +49,7 @@ pub use cleaner::CacheCleaner;
 /// Maintenance options. Use [`MaintenanceOptsBuilder`] to create.
 #[derive(Default, Builder, Debug)]
 #[builder(setter(into))]
+#[builder(default)]
 pub struct MaintenanceOpts {
     /// Run cache cleaning.
     ///
@@ -250,3 +251,109 @@ impl<'c> MaintenanceRunner<'c> {
 
 // TODO: Asynchronously handle files in maintenance runner.
 //       Right now we synchronously iterate over files, which is not efficient.
+
+// #[cfg(test)]
+// mod fixtures {
+//     use super::{MaintenanceOpts, MaintenanceRunner};
+//     use crate::client::fixtures::ClientFixture;
+//     use crate::database::api;
+//     use crate::FileStatus;
+//     use tokio::fs;
+
+//     type Error = Box<dyn std::error::Error>;
+
+//     pub struct CarolFixture {
+//         pub client: ClientFixture,
+//     }
+
+//     impl CarolFixture {
+//         pub async fn new() -> Result<Self, Error> {
+//             Ok(Self {
+//                 client: ClientFixture::new().await?,
+//             })
+//         }
+
+//         pub fn runner(&mut self) -> MaintenanceRunner {
+//             MaintenanceRunner::new(
+//                 &mut self.client.client,
+//                 MaintenanceOpts::builder().build().unwrap(),
+//             )
+//         }
+
+//         pub async fn with_entry(mut self) -> Result<Self, Error> {
+//             let url = format!("{}/file.txt", &self.client.host);
+//             let file = self.client.client.get(&url).await?;
+//             file.release().await?;
+//             Ok(self)
+//         }
+
+//         pub async fn remove_file(mut self) -> Result<Self, Error> {
+//             self = self.with_entry().await?;
+//             let url = format!("{}/file.txt", &self.client.host);
+//             let file = self.client.client.find(&url).await?.unwrap();
+//             fs::remove_file(file.cache_path()).await?;
+//             file.release().await?;
+//             Ok(self)
+//         }
+
+//         pub async fn with_corrupted_entry(mut self) -> Result<Self, Error> {
+//             self = self.with_entry().await?;
+//             let url = format!("{}/file.txt", &self.client.host);
+//             let pk = api::get_by_url(&mut self.client.client.db, &url)
+//                 .await?
+//                 .unwrap()
+//                 .id;
+//             api::update_status(&mut self.client.client.db, pk, FileStatus::Corrupted).await?;
+//             Ok(self)
+//         }
+//     }
+// }
+
+// #[cfg(test)]
+// mod tests {
+//     use super::fixtures::CarolFixture;
+//     use crate::FileStatus;
+//     use tracing_test::traced_test;
+
+//     #[tokio::test]
+//     #[traced_test]
+//     async fn test_find_corrupted_cache_entries() {
+//         let mut fixture = CarolFixture::new()
+//             .await
+//             .unwrap()
+//             .remove_file()
+//             .await
+//             .unwrap();
+//         let mut runner = fixture.runner();
+
+//         runner
+//             .find_corrupted_cache_entries()
+//             .await
+//             .expect("find corrupted cache entries");
+
+//         let url = format!("{}/file.txt", &fixture.client.host);
+//         let file = fixture.client.client.get(&url).await.unwrap();
+//         assert_eq!(file.status().await.unwrap(), FileStatus::Corrupted);
+//     }
+
+//     #[tokio::test]
+//     #[traced_test]
+//     async fn test_remove_corrupted_cache_entries() {
+//         let mut fixture = CarolFixture::new()
+//             .await
+//             .unwrap()
+//             .with_corrupted_entry()
+//             .await
+//             .unwrap();
+//         let mut runner = fixture.runner();
+
+//         runner
+//             .remove_corrupted_entries()
+//             .await
+//             .expect("remove corrupted cache entries");
+
+//         let url = format!("{}/file.txt", &fixture.client.host);
+//         let file = fixture.client.client.find(&url).await.unwrap();
+//         assert!(file.is_none());
+//     }
+// }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -69,14 +69,13 @@ pub type Pool = managed::Pool<PoolManager>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempdir::TempDir;
 
     #[tokio::test]
     async fn test_pool_build() {
-        let tmp_database = TempDir::new("carol.test.database").unwrap();
+        let tmp_database = tempfile::tempdir().unwrap();
         let database = tmp_database.path().join("carol.sqlite");
         let database_path = database.as_os_str().to_str().unwrap().to_string();
-        let tmp_cache_dir = TempDir::new("carol.test.database").unwrap();
+        let tmp_cache_dir = tempfile::tempdir().unwrap();
 
         let mgr = PoolManager::new(&database_path, tmp_cache_dir.path());
         let pool = Pool::builder(mgr).max_size(16).build().expect("build pool");
@@ -96,10 +95,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_small_pool() {
-        let tmp_database = TempDir::new("carol.test.database").unwrap();
+        let tmp_database = tempfile::tempdir().unwrap();
         let database = tmp_database.path().join("carol.sqlite");
         let database_path = database.as_os_str().to_str().unwrap().to_string();
-        let tmp_cache_dir = TempDir::new("carol.test.database").unwrap();
+        let tmp_cache_dir = tempfile::tempdir().unwrap();
 
         let mgr = PoolManager::new(&database_path, tmp_cache_dir.path());
         let pool = Pool::builder(mgr).max_size(1).build().expect("build pool");

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,7 +1,6 @@
 //! Client integration tests.
 
 use std::process::{Command, Stdio};
-use tempdir::TempDir;
 use tokio::fs;
 
 use carol::pool::{Pool, PoolManager};
@@ -21,7 +20,7 @@ where
 
 #[tokio::test]
 async fn test_with_one_file() -> anyhow::Result<()> {
-    let tmp = TempDir::new("carol.test")?;
+    let tmp = tempfile::tempdir()?;
     let db_path = tmp.path().join("carol.sqlite");
     let db_path_str = format!("{}", db_path.display());
     let cache_dir = tmp.path().join("files");
@@ -43,7 +42,7 @@ async fn test_with_one_file() -> anyhow::Result<()> {
 async fn test_with_many_files() -> anyhow::Result<()> {
     // This test shows how to use connection pool to fetch multiple files at the same time
 
-    let tmp = TempDir::new("carol.test")?;
+    let tmp = tempfile::tempdir()?;
     let db_path = tmp.path().join("carol.sqlite");
     let db_path_str = format!("{}", db_path.display());
     let cache_dir = tmp.path().join("files");


### PR DESCRIPTION
* Use `rstest` fixtures in tests

* Fix a number of bugs along the way

* Fix `ClientBuilder` `self` argument type

* Remove deprecated crate `tempdir`

* Refine clean-up after failed downloading case

* Enable tarpaulin in CI