### PR TITLE
Fix Typos in Documentation Comments

### DIFF
--- a/carol/src/error.rs
+++ b/carol/src/error.rs
@@ -11,7 +11,7 @@ pub struct NonUtf8PathError;
 /// Carol storage error.
 #[derive(thiserror::Error, Debug)]
 pub enum StorageError<E: StorageDatabaseError> {
-    /// Storage database releated error
+    /// Storage database related error
     #[error("database error")]
     DatabaseError(#[from] E),
 

--- a/carol/src/storage_config.rs
+++ b/carol/src/storage_config.rs
@@ -29,7 +29,7 @@ pub struct StorageConfig {
     /// space. It is recommended for users to manually restrict the size of the storage, e.g. by
     /// placing it on a separate filesystem.
     ///
-    /// When "no space left" error occures, storage manager will invoke this policy in attemp to
+    /// When "no space left" error occurs, storage manager will invoke this policy in attempt to
     /// free space.
     ///
     /// Default eviction policy is [`EvictionPolicy::Lru`].


### PR DESCRIPTION


**Description:** 
This pull request addresses minor typographical errors in the documentation comments within the codebase. Specifically, it corrects the spelling of "related" in `error.rs` and "occurs" in `storage_config.rs`. These changes improve the clarity and professionalism of the documentation.
